### PR TITLE
feature/#23 : jpa-entity 모듈에서 스키마 추출 및 도커 자동 런 태스크 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ auth/application.yml
 .tool-versions
 
 **/src/generated
+
+### mysql-docker init script ###
+docker/mysql-init-files/**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.avast.gradle.dockercompose.ComposeExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 java.sourceCompatibility = JavaVersion.VERSION_17
@@ -9,6 +10,7 @@ plugins {
     id("org.springframework.boot") version "3.0.4" apply false
     id("io.spring.dependency-management") version "1.1.0" apply false
     id("nu.studer.jooq") version "8.1" apply false
+    id("com.avast.gradle.docker-compose") version "0.16.12" apply false
 }
 
 allprojects {
@@ -19,18 +21,24 @@ allprojects {
         mavenCentral()
     }
 
+    ext {
+        set("mysqlDockerComposePath", "$rootDir/docker/docker-compose.yml")
+    }
 }
 
 subprojects {
     apply(plugin = "java")
-
+    apply(plugin = "kotlin")
     apply(plugin = "io.spring.dependency-management")
     apply(plugin = "org.springframework.boot")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
 
-    apply(plugin = "kotlin")
     apply(plugin = "kotlin-spring")
     apply(plugin = "nu.studer.jooq")
+
+    apply(plugin = "com.avast.gradle.docker-compose")
+
+    val dockerComposePath = ext.get("mysqlDockerComposePath") as String
 
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -38,7 +46,6 @@ subprojects {
         implementation("org.springframework.boot:spring-boot-starter")
         implementation("org.springframework.boot:spring-boot-starter-webflux")
     }
-
 
     tasks.withType<KotlinCompile> {
         kotlinOptions {
@@ -54,6 +61,22 @@ subprojects {
     configurations {
         compileOnly {
             extendsFrom(configurations.annotationProcessor.get())
+        }
+    }
+
+    configure<ComposeExtension> {
+        includeDependencies.set(true)
+
+        createNested("local").apply {
+            executable.set("/usr/local/bin/docker-compose-v1")
+            dockerExecutable.set("/usr/local/bin/docker")
+            dockerComposeWorkingDirectory.set(file("$rootDir"))
+
+            stopContainers.set(false)
+            setProjectName("mysql-local")
+            projectNamePrefix = "mysql-stack"
+
+            useComposeFiles.set(listOf(dockerComposePath))
         }
     }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - 3306:3306
     volumes:
       - ./config:/etc/mysql/conf.d
+      - ./mysql-init-files/:/docker-entrypoint-initdb.d/
     environment:
       - MYSQL_DATABASE=prism_local
       - MYSQL_ROOT_PASSWORD=password

--- a/jpa-entity/build.gradle.kts
+++ b/jpa-entity/build.gradle.kts
@@ -6,8 +6,15 @@ plugins {
     kotlin("plugin.jpa") version "1.8.10"
 }
 
+ext {
+    set("schemaInitPath", "$rootDir/docker/mysql-init-files")
+    set("schemaFileName", "0_init_schema.sql")
+}
+
 dependencies {
-    implementation ("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.reflections:reflections:0.10.2")
+    implementation("org.hibernate.orm:hibernate-ant:6.1.4.Final")
 }
 
 allOpen {
@@ -22,4 +29,44 @@ tasks.named<BootJar>("bootJar") {
 
 tasks.named<Jar>("jar") {
     enabled = true
+    val generateSchemaTask = getTasksByName("generateSchemaSQL", false).first()
+    dependsOn(generateSchemaTask)
+
+    this.mustRunAfter(generateSchemaTask)
+}
+
+tasks.register<JavaExec>("generateSchemaSQL") {
+
+    val schemaInitPath = ext.get("schemaInitPath") as String
+    val schemaFileName = ext.get("schemaFileName") as String
+
+    doFirst {
+        val folder = File(schemaInitPath)
+        if (folder.exists()) {
+            folder.listFiles()?.forEach { file ->
+                file.delete()
+            }
+        } else {
+            folder.mkdirs()
+        }
+    }
+
+    mainClass.set("io.prism.GenerateSchemaSQL")
+    classpath = sourceSets["main"].runtimeClasspath
+
+    systemProperty("hibernate.dialect.storage_engine", "innodb")
+    args("$schemaInitPath/$schemaFileName")
+}
+
+tasks.register("runDockerCompose") {
+    val generateSchemaTask = getTasksByName("generateSchemaSQL", false).first()
+    val dockerComposeDownTask = getTasksByName("localComposeDownForced", false).first()
+    val dockerComposeUpTask = getTasksByName("localComposeUp", false).first()
+
+    dependsOn(generateSchemaTask)
+    dependsOn(dockerComposeDownTask)
+    dependsOn(dockerComposeUpTask)
+
+    dockerComposeDownTask.mustRunAfter(generateSchemaTask)
+    dockerComposeUpTask.mustRunAfter(dockerComposeDownTask)
 }

--- a/jpa-entity/src/main/kotlin/io/prism/GenerateSchemaSQL.kt
+++ b/jpa-entity/src/main/kotlin/io/prism/GenerateSchemaSQL.kt
@@ -1,0 +1,49 @@
+package io.prism
+
+import jakarta.persistence.Entity
+import org.hibernate.boot.MetadataSources
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder
+import org.hibernate.tool.hbm2ddl.SchemaExport
+import org.hibernate.tool.schema.TargetType
+import org.reflections.Reflections
+import java.util.*
+
+
+private const val SCHEMA_GENERATE_TARGET_PACKAGE = "io.prism.entity"
+
+private const val SCHEMA_DELIMITER = ";"
+
+object GenerateSchemaSQL {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val outputFilePath = args[0]
+
+        val settings: Map<String, String> =
+            mapOf(
+                "hibernate.dialect" to "org.hibernate.dialect.MySQLDialect"
+            )
+
+
+        val metadata = MetadataSources(
+            StandardServiceRegistryBuilder()
+                .applySettings(settings)
+                .build()
+        )
+
+        val entityClasses = Reflections(SCHEMA_GENERATE_TARGET_PACKAGE)
+            .getTypesAnnotatedWith(Entity::class.java)
+
+        for (clazz in entityClasses) {
+            metadata.addAnnotatedClass(clazz)
+        }
+
+        SchemaExport()
+            .setDelimiter(SCHEMA_DELIMITER)
+            .setOutputFile(outputFilePath)
+            .setFormat(true)
+            .createOnly(
+                EnumSet.of(TargetType.SCRIPT),
+                metadata.buildMetadata()
+            )
+    }
+}


### PR DESCRIPTION
+ feature/#23 : Schema 자동 추출 및 도커 플러그인을 통해 빌드되게끔 스크립트 수정
+ chore/#23 : gitignore 추가
+ feature/#23 : mysql docker Schema Init 되게끔 수정 및 jpa-entity 모듈도커 컴포즈 Task 추가

#### 공유사항 

`jpa-entity` 모듈에서 `@Entity` 어노테이션이 달린 클래스 대상으로 `.sql` 파일 추출 
-> 이 파일은 `docker/mysql-init-files` 경로로 떨어지게끔하고, 해당 경로를 `docker-entrypoint-initdb.d`로 마운트 
-> 이를 통해 `docker-compose up` 시에 자동 스키마 생성 

이러한 태스크를 필요한 모듈에서 가져가게끔하면 자동 구성 처리 완료가 될 것 같습니다.

#### 관련이슈

#23 